### PR TITLE
Molding the API both from a kotlin and from a java project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ subprojects {
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2")
 
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
         testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.8")

--- a/subprojects/example_javaclient/example_javaclient.gradle.kts
+++ b/subprojects/example_javaclient/example_javaclient.gradle.kts
@@ -1,3 +1,7 @@
 dependencies {
     implementation(project(":kris"))
+
+    implementation("io.reactivex.rxjava2:rxjava:2.2.13")
+
+    testImplementation("org.assertj:assertj-core:3.13.2")
 }

--- a/subprojects/example_javaclient/src/test/java/ch/difty/kris/example/java/KrisUsageTest.java
+++ b/subprojects/example_javaclient/src/test/java/ch/difty/kris/example/java/KrisUsageTest.java
@@ -11,9 +11,12 @@ import com.gmail.gcolaianni5.jris.JRis;
 import com.gmail.gcolaianni5.jris.RisRecord;
 import com.gmail.gcolaianni5.jris.RisType;
 import io.reactivex.Observable;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class KrisUsageTest {
+
+    private static final String SKIP_REASON = "Function currently lacking implementation";
 
     //@formatter:off
     @SuppressWarnings("SpellCheckingInspection") private final List<String> risLines = Arrays.asList(
@@ -38,12 +41,14 @@ class KrisUsageTest {
     );
     //@formatter:on
 
+    @Disabled(SKIP_REASON)
     @Test
     void whenProcessingRisLinesAsList_willReturnListOfRisRecords() {
         final List<RisRecord> risRecords = JRis.processList(risLines);
         assertThat(risRecords).hasSize(2);
     }
 
+    @Disabled(SKIP_REASON)
     @Test
     void whenProcessingRisLinesAsObservable_willReturnObservableOfRisRecords() {
         final List<RisRecord> risRecords = new ArrayList<>();
@@ -72,12 +77,14 @@ class KrisUsageTest {
 
     private final int expectedLineCount = 9;
 
+    @Disabled(SKIP_REASON)
     @Test
     void whenProcessingRisRecordsAsList_willReturnListOfRisLines() {
         final List<String> risLines = JRis.exportList(risRecords);
         assertThat(risLines).hasSize(expectedLineCount);
     }
 
+    @Disabled(SKIP_REASON)
     @Test
     void whenProcessingRisRecordsAsObservable_willReturnObservableOfRisLines() {
         final List<String> risLines = new ArrayList<>();

--- a/subprojects/example_javaclient/src/test/java/ch/difty/kris/example/java/KrisUsageTest.java
+++ b/subprojects/example_javaclient/src/test/java/ch/difty/kris/example/java/KrisUsageTest.java
@@ -1,29 +1,93 @@
 package ch.difty.kris.example.java;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import com.gmail.gcolaianni5.jris.JRis;
+import com.gmail.gcolaianni5.jris.RisRecord;
+import com.gmail.gcolaianni5.jris.RisType;
+import io.reactivex.Observable;
 import org.junit.jupiter.api.Test;
 
 class KrisUsageTest {
 
-    @Test
-    void canParse() {
-        //@formatter:off
-        List<String> singleEntryRis = Arrays.asList(
-            "TY  - JOUR",
-            "AU  - Shannon, Claude E.",
-            "PY  - 1948/07//",
-            "TI  - A Mathematical Theory of Communication",
-            "T2  - Bell System Technical Journal",
-            "SP  - 379",
-            "EP  - 423",
-            "VL  - 27",
-            "ER  - "
-        );
-        //@formatter:on
+    //@formatter:off
+    @SuppressWarnings("SpellCheckingInspection") private final List<String> risLines = Arrays.asList(
+        "TY  - JOUR",
+        "AU  - Shannon, Claude E.",
+        "PY  - 1948/07//",
+        "TI  - A Mathematical Theory of Communication",
+        "T2  - Bell System Technical Journal",
+        "SP  - 379",
+        "EP  - 423",
+        "VL  - 27",
+        "ER  - ",
+        "TY  - JOUR",
+        "TI  - Die Grundlage der allgemeinen Relativitätstheorie",
+        "AU  - Einstein, Albert",
+        "PY  - 1916",
+        "SP  - 769",
+        "EP  - 822",
+        "JO  - Annalen der Physik",
+        "VL  - 49",
+        "ER  -"
+    );
+    //@formatter:on
 
-        //List<RisRecord> records = JRis.INSTANCE.parse(singleEntryRis)
-        // TODO develop API
+    @Test
+    void whenProcessingRisLinesAsList_willReturnListOfRisRecords() {
+        final List<RisRecord> risRecords = JRis.processList(risLines);
+        assertThat(risRecords).hasSize(2);
+    }
+
+    @Test
+    void whenProcessingRisLinesAsObservable_willReturnObservableOfRisRecords() {
+        final List<RisRecord> risRecords = new ArrayList<>();
+
+        final Observable<String> observable = Observable.fromIterable(risLines);
+
+        JRis
+            .parseFromObservable(observable)
+            .blockingSubscribe(risRecords::add);
+
+        assertThat(risRecords).hasSize(2);
+    }
+
+    private final RisRecord risRecord = new RisRecord.Builder()
+        .type(RisType.JOUR)
+        .authors(Collections.singletonList("Shannon, Claude E."))
+        .publicationYear("1948/07//")
+        .title("A Mathematical Theory of Communication")
+        .secondaryTitle("Bell System Technical Journal")
+        .startPage("379")
+        .endPage("423")
+        .volumeNumber("27")
+        .build();
+
+    private final List<RisRecord> risRecords = Collections.singletonList(risRecord);
+
+    private final int expectedLineCount = 9;
+
+    @Test
+    void whenProcessingRisRecordsAsList_willReturnListOfRisLines() {
+        final List<String> risLines = JRis.exportList(risRecords);
+        assertThat(risLines).hasSize(expectedLineCount);
+    }
+
+    @Test
+    void whenProcessingRisRecordsAsObservable_willReturnObservableOfRisLines() {
+        final List<String> risLines = new ArrayList<>();
+
+        final Observable<RisRecord> observable = Observable.fromIterable(risRecords);
+
+        JRis
+            .exportObservable(observable)
+            .blockingSubscribe(risLines::add);
+
+        assertThat(risLines).hasSize(expectedLineCount);
     }
 }

--- a/subprojects/example_kotlinclient/src/test/kotlin/ch/difty/kris/example/kotlin/KrisUsageSpec.kt
+++ b/subprojects/example_kotlinclient/src/test/kotlin/ch/difty/kris/example/kotlin/KrisUsageSpec.kt
@@ -8,7 +8,10 @@ import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldHaveSize
 import org.spekframework.spek2.Spek
+import org.spekframework.spek2.dsl.Skip
 import org.spekframework.spek2.style.specification.describe
+
+private const val SKIP_REASON = "Functionality not implemented yet"
 
 object KrisUsageSpec : Spek({
 
@@ -37,14 +40,14 @@ object KrisUsageSpec : Spek({
         )
 
 
-        it("can be passed to a static method returning a list of RisRecords (blocking)") {
+        it("can be passed to a static method returning a list of RisRecords (blocking)", skip = Skip.Yes(SKIP_REASON)) {
             JRis.process(risLines) shouldHaveSize 2
         }
 
         describe("converted to Flow") {
             val flowOfRisLines: Flow<String> = risLines.asFlow()
 
-            it("can be passed to a flow operator returning a flow of RisRecords (non-blocking)") {
+            it("can be passed to a flow operator returning a flow of RisRecords (non-blocking)", skip = Skip.Yes(SKIP_REASON)) {
                 runBlocking {
                     flowOfRisLines
                         .toRisRecords()
@@ -57,14 +60,14 @@ object KrisUsageSpec : Spek({
         describe("converted to a Sequence") {
             val sequenceOfRisLines: Sequence<String> = risLines.asSequence()
 
-            it("can be passed to a sequence operator returning a sequence of RisRecords (blocking)") {
+            it("can be passed to a sequence operator returning a sequence of RisRecords (blocking)", skip = Skip.Yes(SKIP_REASON)) {
                 sequenceOfRisLines
                     .toRisRecords()
                     .toList()
                     .shouldHaveSize(2)
             }
 
-            it("can be passed to a static method returning a list of RisRecords (blocking)") {
+            it("can be passed to a static method returning a list of RisRecords (blocking)", skip = Skip.No) {
                 JRis.process(sequenceOfRisLines) shouldHaveSize 2
             }
         }
@@ -85,11 +88,11 @@ object KrisUsageSpec : Spek({
 
         val risRecords = listOf(risRecord)
 
-        it("can be passed to a static method returning a list of Strings (blocking)") {
+        it("can be passed to a static method returning a list of Strings (blocking)", skip = Skip.Yes(SKIP_REASON)) {
             JRis.export(risRecords) shouldHaveSize 9
         }
 
-        describe("converted to Flow") {
+        describe("converted to Flow", skip = Skip.Yes(SKIP_REASON)) {
             val flowOfRisRecords: Flow<RisRecord> = risRecords.asFlow()
 
             it("can be passed to a flow operator returning a flow of Strings (non-blocking)") {
@@ -102,7 +105,7 @@ object KrisUsageSpec : Spek({
             }
         }
 
-        describe("converted to a Sequence") {
+        describe("converted to a Sequence", skip = Skip.Yes(SKIP_REASON)) {
             val sequenceOfRisRecords: Sequence<RisRecord> = risRecords.asSequence()
 
             it("can be passed to a sequence operator returning a sequence of Strings (blocking)") {
@@ -114,8 +117,8 @@ object KrisUsageSpec : Spek({
         }
 
 
-        it("can convert risRecord to a string") {
-            risRecords shouldEqual """TY  - JOUR
+        it("can convert risRecord to a string", skip = Skip.No) {
+            JRis.build(records = risRecords) shouldEqual """TY  - JOUR
                                 |AU  - Shannon, Claude E.
                                 |EP  - 423
                                 |PY  - 1948/07//

--- a/subprojects/example_kotlinclient/src/test/kotlin/ch/difty/kris/example/kotlin/KrisUsageSpec.kt
+++ b/subprojects/example_kotlinclient/src/test/kotlin/ch/difty/kris/example/kotlin/KrisUsageSpec.kt
@@ -1,8 +1,10 @@
 package ch.difty.kris.example.kotlin
 
-import com.gmail.gcolaianni5.jris.JRis
-import com.gmail.gcolaianni5.jris.RisRecord
-import com.gmail.gcolaianni5.jris.RisType
+import com.gmail.gcolaianni5.jris.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldHaveSize
 import org.spekframework.spek2.Spek
@@ -10,9 +12,10 @@ import org.spekframework.spek2.style.specification.describe
 
 object KrisUsageSpec : Spek({
 
-    describe("with RIS file as list of strings representing") {
-        // example from wikipedia (https://en.wikipedia.org/wiki/RIS_(file_format))
-        val lines = listOf(
+    describe("with list of strings representing two RIS records") {
+        // example from wikipedia (https://en.wikipedia.org/wiki/RIS_(file_format)
+        // and https://de.wikipedia.org/wiki/RIS_(Dateiformat))
+        val risLines: List<String> = listOf(
             "TY  - JOUR",
             "AU  - Shannon, Claude E.",
             "PY  - 1948/07//",
@@ -21,17 +24,53 @@ object KrisUsageSpec : Spek({
             "SP  - 379",
             "EP  - 423",
             "VL  - 27",
-            "ER  - "
+            "ER  - ",
+            "TY  - JOUR",
+            "TI  - Die Grundlage der allgemeinen Relativitätstheorie",
+            "AU  - Einstein, Albert",
+            "PY  - 1916",
+            "SP  - 769",
+            "EP  - 822",
+            "JO  - Annalen der Physik",
+            "VL  - 49",
+            "ER  -"
         )
 
-        it("can parse lines as sequence returning list") {
-            JRis.parse(lines.asSequence()) shouldHaveSize 1
+
+        it("can be passed to a static method returning a list of RisRecords (blocking)") {
+            JRis.process(risLines) shouldHaveSize 2
         }
 
-        // TODO develop API for parsing
+        describe("converted to Flow") {
+            val flowOfRisLines: Flow<String> = risLines.asFlow()
+
+            it("can be passed to a flow operator returning a flow of RisRecords (non-blocking)") {
+                runBlocking {
+                    flowOfRisLines
+                        .toRisRecords()
+                        .toList()
+                        .shouldHaveSize(2)
+                }
+            }
+        }
+
+        describe("converted to a Sequence") {
+            val sequenceOfRisLines: Sequence<String> = risLines.asSequence()
+
+            it("can be passed to a sequence operator returning a sequence of RisRecords (blocking)") {
+                sequenceOfRisLines
+                    .toRisRecords()
+                    .toList()
+                    .shouldHaveSize(2)
+            }
+
+            it("can be passed to a static method returning a list of RisRecords (blocking)") {
+                JRis.process(sequenceOfRisLines) shouldHaveSize 2
+            }
+        }
     }
 
-    describe("with RisRecord") {
+    describe("with a list with a single RisRecord") {
         val risRecord = RisRecord(
             type = RisType.JOUR,
             authors = mutableListOf("Shannon, Claude E."),
@@ -42,10 +81,41 @@ object KrisUsageSpec : Spek({
             endPage = "423",
             volumeNumber = " 27"
         )
+        val expectedLinesInFile = 9 // including ER (End of Record)
 
-        val lines by memoized { JRis.build(records = listOf(risRecord)) }
+        val risRecords = listOf(risRecord)
+
+        it("can be passed to a static method returning a list of Strings (blocking)") {
+            JRis.export(risRecords) shouldHaveSize 9
+        }
+
+        describe("converted to Flow") {
+            val flowOfRisRecords: Flow<RisRecord> = risRecords.asFlow()
+
+            it("can be passed to a flow operator returning a flow of Strings (non-blocking)") {
+                runBlocking {
+                    flowOfRisRecords
+                        .toRisLines()
+                        .toList()
+                        .shouldHaveSize(expectedLinesInFile)
+                }
+            }
+        }
+
+        describe("converted to a Sequence") {
+            val sequenceOfRisRecords: Sequence<RisRecord> = risRecords.asSequence()
+
+            it("can be passed to a sequence operator returning a sequence of Strings (blocking)") {
+                sequenceOfRisRecords
+                    .toRisLines()
+                    .toList()
+                    .shouldHaveSize(expectedLinesInFile)
+            }
+        }
+
+
         it("can convert risRecord to a string") {
-            lines shouldEqual """TY  - JOUR
+            risRecords shouldEqual """TY  - JOUR
                                 |AU  - Shannon, Claude E.
                                 |EP  - 423
                                 |PY  - 1948/07//
@@ -58,3 +128,4 @@ object KrisUsageSpec : Spek({
         }
     }
 })
+

--- a/subprojects/kris/kris.gradle.kts
+++ b/subprojects/kris/kris.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation("io.reactivex.rxjava2:rxjava:2.2.13")
+    implementation("io.reactivex.rxjava2:rxkotlin:2.4.0")
+}

--- a/subprojects/kris/src/main/kotlin/com/gmail/gcolaianni5/jris/JRis.kt
+++ b/subprojects/kris/src/main/kotlin/com/gmail/gcolaianni5/jris/JRis.kt
@@ -2,6 +2,8 @@
 
 package com.gmail.gcolaianni5.jris
 
+import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import java.io.*
 import kotlin.math.min
 import kotlin.reflect.KClass
@@ -118,14 +120,14 @@ object JRis {
 
     private val tag2accessor: Map<String, TagAccessor> = tagAccessors.map { it.tag.name to it }.toMap()
 
-    //region:import
+//region:import
 
     /**
      * Accepts a sequence of Strings representing lines in a RIS file
      * to return a list of [RisRecord]s. Throws a [JRisException] if
      * the lines cannot be parsed appropriately.
      */
-    fun parse(sequence: Sequence<String>): List<RisRecord> {
+    fun process(sequence: Sequence<String>): List<RisRecord> {
         val records = mutableListOf<RisRecord>()
 
         var record: RisRecord = RisRecord()
@@ -185,14 +187,24 @@ object JRis {
         else -> this
     }
 
+    /**
+     * Processes as list of Strings (representing single lines in RIS file format)
+     * into a list of [RisRecord]s
+     */
+    @JvmStatic
+    fun processList(risLines: List<String>): List<RisRecord> = TODO()
+
+    @JvmStatic
+    fun parseFromObservable(risLineObservable: Observable<String>): Observable<RisRecord> = TODO()
+
 //endregion
 
 //region:export
 
     /**
      * Builds the content of a RIS file and returns it as String.
-     * TODO use something more efficient for big files
      */
+    @Deprecated("Replace with non-blocking calls")
     fun build(records: List<RisRecord>, sort: List<String> = emptyList()): String {
         check(records.isNotEmpty()) { throw JRisException("Record list must not be empty.") }
         return records.asString(sort.withIndex().associate { RisTag.valueOf(it.value) to it.index }.toMap())
@@ -233,22 +245,34 @@ object JRis {
         }
     }
 
+    /**
+     * Transforms a list of [RisRecord]s into a list of Strings.
+     */
+    @JvmStatic
+    fun exportList(risRecords: List<RisRecord>): List<String> = TODO()
+
+    /**
+     * Transforms an observable of [RisRecord]s into an observable of Strings.
+     */
+    @JvmStatic
+    fun exportObservable(observable: Observable<RisRecord>): Observable<String> = TODO()
+
 //endregion
 }
 
 //region:helperMethodsForImportingRis
 
 @Throws(IOException::class, JRisException::class)
-fun parse(reader: Reader): List<RisRecord> = JRis.parse(BufferedReader(reader).readLines().asSequence())
+fun process(reader: Reader): List<RisRecord> = JRis.process(BufferedReader(reader).readLines().asSequence())
 
 @Throws(IOException::class, JRisException::class)
-fun parse(file: File): List<RisRecord> = parse(file.bufferedReader())
+fun process(file: File): List<RisRecord> = process(file.bufferedReader())
 
 @Throws(IOException::class, JRisException::class)
-fun parse(filePath: String): List<RisRecord> = parse(File(filePath).bufferedReader())
+fun process(filePath: String): List<RisRecord> = process(File(filePath).bufferedReader())
 
 @Throws(IOException::class, JRisException::class)
-fun parse(inputStream: InputStream): List<RisRecord> = parse(inputStream.bufferedReader())
+fun process(inputStream: InputStream): List<RisRecord> = process(inputStream.bufferedReader())
 
 //endregion
 
@@ -282,4 +306,43 @@ fun build(records: List<RisRecord>, filePath: String): Boolean {
         return build(records, it)
     }
 }
+//endregion
+
+//region:todo
+
+/**
+ * Processes a list of strings (lines from a RIS formatted file)
+ * into a list of [RisRecord]
+ */
+fun JRis.process(risLines: List<String>): List<RisRecord> = TODO()
+
+/**
+ * Transforms a flow of Strings (lines from a RIS formatted file) as receiver
+ * into a flow of [RisRecord]s.
+ */
+fun Flow<String>.toRisRecords(): Flow<RisRecord> = TODO()
+
+/**
+ * Transforms a sequence of Strings (lines from a RIS formatted file) as receiver
+ * into a sequence of [RisRecord]s.
+ */
+fun Sequence<String>.toRisRecords(): Sequence<RisRecord> = TODO()
+
+/**
+ * Processes a list of RisRecords into a list of Strings compliant with the RIS file format.
+ */
+fun JRis.export(risRecords: List<RisRecord>): List<String> = TODO()
+
+/**
+ * Processes a flow of [RisRecord]s into a flow of Strings
+ * representing lines in RIS file format.
+ */
+fun Flow<RisRecord>.toRisLines(): Flow<String> = TODO()
+
+/**
+ * Processes a sequence of [RisRecord]s into a sequence of Strings
+ * representing lines in RIS file format.
+ */
+fun Sequence<RisRecord>.toRisLines(): Sequence<String> = TODO()
+
 //endregion

--- a/subprojects/kris/src/main/kotlin/com/gmail/gcolaianni5/jris/RisRecord.kt
+++ b/subprojects/kris/src/main/kotlin/com/gmail/gcolaianni5/jris/RisRecord.kt
@@ -8,7 +8,7 @@ package com.gmail.gcolaianni5.jris
  * @since 22 apr 2017
  */
 @Suppress("ParameterListWrapping", "SpellCheckingInspection")
-data class RisRecord(
+data class RisRecord @JvmOverloads constructor(
 
     /** TY */
     var type: RisType? = null,
@@ -289,4 +289,248 @@ data class RisRecord(
 
     /** Y2 */
     var accessDate: String? = null
-)
+
+) {
+    // This whole bloating builder is only necessary for Java operatbility.
+    data class Builder(
+        var type: RisType? = null,
+        val firstAuthors: MutableList<String> = mutableListOf(),
+        val secondaryAuthors: MutableList<String> = mutableListOf(),
+        val tertiaryAuthors: MutableList<String> = mutableListOf(),
+        val subsidiaryAuthors: MutableList<String> = mutableListOf(),
+        var authors: MutableList<String> = mutableListOf(),
+        var abstr: String? = null,
+        var authorAddress: String? = null,
+        var accessionNumber: String? = null,
+        var archivesLocation: String? = null,
+        var bt: String? = null,
+        var custom1: String? = null,
+        var custom2: String? = null,
+        var custom3: String? = null,
+        var custom4: String? = null,
+        var custom5: String? = null,
+        var custom6: String? = null,
+        var custom7: String? = null,
+        var custom8: String? = null,
+        var caption: String? = null,
+        var callNumber: String? = null,
+        var cp: String? = null,
+        var unpublishedReferenceTitle: String? = null,
+        var placePublished: String? = null,
+        var date: String? = null,
+        var databaseName: String? = null,
+        var doi: String? = null,
+        var databaseProvider: String? = null,
+        var editor: String? = null,
+        var endPage: String? = null,
+        var edition: String? = null,
+        var referenceId: String? = null,
+        var issue: String? = null,
+        var periodicalNameUserAbbrevation: String? = null,
+        var alternativeTitle: String? = null,
+        var periodicalNameStandardAbbrevation: String? = null,
+        var periodicalNameFullFormatJF: String? = null,
+        var periodicalNameFullFormatJO: String? = null,
+        val keywords: MutableList<String> = mutableListOf(),
+        val pdfLinks: MutableList<String> = mutableListOf(),
+        val fullTextLinks: MutableList<String> = mutableListOf(),
+        val relatedRecords: MutableList<String> = mutableListOf(),
+        val images: MutableList<String> = mutableListOf(),
+        var language: String? = null,
+        var label: String? = null,
+        var websiteLink: String? = null,
+        var number: Long? = null,
+        var miscellaneous2: String? = null,
+        var typeOfWork: String? = null,
+        var notes: String? = null,
+        var abstr2: String? = null,
+        var numberOfVolumes: String? = null,
+        var originalPublication: String? = null,
+        var publisher: String? = null,
+        var publishingPlace: String? = null,
+        var publicationYear: String? = null,
+        var reviewedItem: String? = null,
+        var researchNotes: String? = null,
+        var reprintEdition: String? = null,
+        var section: String? = null,
+        var isbnIssn: String? = null,
+        var startPage: String? = null,
+        var shortTitle: String? = null,
+        var primaryTitle: String? = null,
+        var secondaryTitle: String? = null,
+        var tertiaryTitle: String? = null,
+        var translatedAuthor: String? = null,
+        var title: String? = null,
+        var translatedTitle: String? = null,
+        var userDefinable1: String? = null,
+        var userDefinable2: String? = null,
+        var userDefinable3: String? = null,
+        var userDefinable4: String? = null,
+        var userDefinable5: String? = null,
+        var url: String? = null,
+        var volumeNumber: String? = null,
+        var publisherStandardNumber: String? = null,
+        var primaryDate: String? = null,
+        var accessDate: String? = null) {
+
+        fun type(type: RisType?) = apply { this.type = type }
+        fun firstAuthors(firstAuthors: MutableList<String>) = apply { this.firstAuthors.clear(); this.firstAuthors.addAll(firstAuthors) }
+        fun secondaryAuthors(secondaryAuthors: MutableList<String>) = apply { this.secondaryAuthors.clear(); this.secondaryAuthors.addAll(secondaryAuthors) }
+        fun tertiaryAuthors(tertiaryAuthors: MutableList<String>) = apply { this.tertiaryAuthors.clear(); this.tertiaryAuthors.addAll(tertiaryAuthors) }
+        fun subsidiaryAuthors(subsidiaryAuthors: MutableList<String>) = apply { this.subsidiaryAuthors.clear(); this.subsidiaryAuthors.addAll(subsidiaryAuthors) }
+        fun authors(authors: MutableList<String>) = apply { this.authors = authors }
+        fun abstr(abstr: String?) = apply { this.abstr = abstr }
+        fun authorAddress(authorAddress: String?) = apply { this.authorAddress = authorAddress }
+        fun accessionNumber(accessionNumber: String?) = apply { this.accessionNumber = accessionNumber }
+        fun archivesLocation(archivesLocation: String?) = apply { this.archivesLocation = archivesLocation }
+        fun bt(bt: String?) = apply { this.bt = bt }
+        fun custom1(custom1: String?) = apply { this.custom1 = custom1 }
+        fun custom2(custom2: String?) = apply { this.custom2 = custom2 }
+        fun custom3(custom3: String?) = apply { this.custom3 = custom3 }
+        fun custom4(custom4: String?) = apply { this.custom4 = custom4 }
+        fun custom5(custom5: String?) = apply { this.custom5 = custom5 }
+        fun custom6(custom6: String?) = apply { this.custom6 = custom6 }
+        fun custom7(custom7: String?) = apply { this.custom7 = custom7 }
+        fun custom8(custom8: String?) = apply { this.custom8 = custom8 }
+        fun caption(caption: String?) = apply { this.caption = caption }
+        fun callNumber(callNumber: String?) = apply { this.callNumber = callNumber }
+        fun cp(cp: String?) = apply { this.cp = cp }
+        fun unpublishedReferenceTitle(unpublishedReferenceTitle: String?) = apply { this.unpublishedReferenceTitle = unpublishedReferenceTitle }
+        fun placePublished(placePublished: String?) = apply { this.placePublished = placePublished }
+        fun date(date: String?) = apply { this.date = date }
+        fun databaseName(databaseName: String?) = apply { this.databaseName = databaseName }
+        fun doi(doi: String?) = apply { this.doi = doi }
+        fun databaseProvider(databaseProvider: String?) = apply { this.databaseProvider = databaseProvider }
+        fun editor(editor: String?) = apply { this.editor = editor }
+        fun endPage(endPage: String?) = apply { this.endPage = endPage }
+        fun edition(edition: String?) = apply { this.edition = edition }
+        fun referenceId(referenceId: String?) = apply { this.referenceId = referenceId }
+        fun issue(issue: String?) = apply { this.issue = issue }
+        fun periodicalNameUserAbbrevation(periodicalNameUserAbbrevation: String?) = apply { this.periodicalNameUserAbbrevation = periodicalNameUserAbbrevation }
+        fun alternativeTitle(alternativeTitle: String?) = apply { this.alternativeTitle = alternativeTitle }
+        fun periodicalNameStandardAbbrevation(periodicalNameStandardAbbrevation: String?) = apply { this.periodicalNameStandardAbbrevation = periodicalNameStandardAbbrevation }
+        fun periodicalNameFullFormatJF(periodicalNameFullFormatJF: String?) = apply { this.periodicalNameFullFormatJF = periodicalNameFullFormatJF }
+        fun periodicalNameFullFormatJO(periodicalNameFullFormatJO: String?) = apply { this.periodicalNameFullFormatJO = periodicalNameFullFormatJO }
+        fun keywords(keywords: MutableList<String>) = apply { this.keywords.clear(); this.keywords.addAll(keywords) }
+        fun pdfLinks(pdfLinks: MutableList<String>) = apply { this.pdfLinks.clear(); this.pdfLinks.addAll(pdfLinks) }
+        fun fullTextLinks(fullTextLinks: MutableList<String>) = apply { this.fullTextLinks.clear(); this.fullTextLinks.addAll(fullTextLinks) }
+        fun relatedRecords(relatedRecords: MutableList<String>) = apply { this.relatedRecords.clear(); this.relatedRecords.addAll(relatedRecords) }
+        fun images(images: MutableList<String>) = apply { this.images.clear(); this.images.addAll(images) }
+        fun language(language: String?) = apply { this.language = language }
+        fun label(label: String?) = apply { this.label = label }
+        fun websiteLink(websiteLink: String?) = apply { this.websiteLink = websiteLink }
+        fun number(number: Long?) = apply { this.number = number }
+        fun miscellaneous2(miscellaneous2: String?) = apply { this.miscellaneous2 = miscellaneous2 }
+        fun typeOfWork(typeOfWork: String?) = apply { this.typeOfWork = typeOfWork }
+        fun notes(notes: String?) = apply { this.notes = notes }
+        fun abstr2(abstr2: String?) = apply { this.abstr2 = abstr2 }
+        fun numberOfVolumes(numberOfVolumes: String?) = apply { this.numberOfVolumes = numberOfVolumes }
+        fun originalPublication(originalPublication: String?) = apply { this.originalPublication = originalPublication }
+        fun publisher(publisher: String?) = apply { this.publisher = publisher }
+        fun publishingPlace(publishingPlace: String?) = apply { this.publishingPlace = publishingPlace }
+        fun publicationYear(publicationYear: String?) = apply { this.publicationYear = publicationYear }
+        fun reviewedItem(reviewedItem: String?) = apply { this.reviewedItem = reviewedItem }
+        fun researchNotes(researchNotes: String?) = apply { this.researchNotes = researchNotes }
+        fun reprintEdition(reprintEdition: String?) = apply { this.reprintEdition = reprintEdition }
+        fun section(section: String?) = apply { this.section = section }
+        fun isbnIssn(isbnIssn: String?) = apply { this.isbnIssn = isbnIssn }
+        fun startPage(startPage: String?) = apply { this.startPage = startPage }
+        fun shortTitle(shortTitle: String?) = apply { this.shortTitle = shortTitle }
+        fun primaryTitle(primaryTitle: String?) = apply { this.primaryTitle = primaryTitle }
+        fun secondaryTitle(secondaryTitle: String?) = apply { this.secondaryTitle = secondaryTitle }
+        fun tertiaryTitle(tertiaryTitle: String?) = apply { this.tertiaryTitle = tertiaryTitle }
+        fun translatedAuthor(translatedAuthor: String?) = apply { this.translatedAuthor = translatedAuthor }
+        fun title(title: String?) = apply { this.title = title }
+        fun translatedTitle(translatedTitle: String?) = apply { this.translatedTitle = translatedTitle }
+        fun userDefinable1(userDefinable1: String?) = apply { this.userDefinable1 = userDefinable1 }
+        fun userDefinable2(userDefinable2: String?) = apply { this.userDefinable2 = userDefinable2 }
+        fun userDefinable3(userDefinable3: String?) = apply { this.userDefinable3 = userDefinable3 }
+        fun userDefinable4(userDefinable4: String?) = apply { this.userDefinable4 = userDefinable4 }
+        fun userDefinable5(userDefinable5: String?) = apply { this.userDefinable5 = userDefinable5 }
+        fun url(url: String?) = apply { this.url = url }
+        fun volumeNumber(volumeNumber: String?) = apply { this.volumeNumber = volumeNumber }
+        fun publisherStandardNumber(publisherStandardNumber: String?) = apply { this.publisherStandardNumber = publisherStandardNumber }
+        fun primaryDate(primaryDate: String?) = apply { this.primaryDate = primaryDate }
+        fun accessDate(accessDate: String?) = apply { this.accessDate = accessDate }
+        fun build() = RisRecord(type,
+            firstAuthors,
+            secondaryAuthors,
+            tertiaryAuthors,
+            subsidiaryAuthors,
+            authors,
+            abstr,
+            authorAddress,
+            accessionNumber,
+            archivesLocation,
+            bt,
+            custom1,
+            custom2,
+            custom3,
+            custom4,
+            custom5,
+            custom6,
+            custom7,
+            custom8,
+            caption,
+            callNumber,
+            cp,
+            unpublishedReferenceTitle,
+            placePublished,
+            date,
+            databaseName,
+            doi,
+            databaseProvider,
+            editor,
+            endPage,
+            edition,
+            referenceId,
+            issue,
+            periodicalNameUserAbbrevation,
+            alternativeTitle,
+            periodicalNameStandardAbbrevation,
+            periodicalNameFullFormatJF,
+            periodicalNameFullFormatJO,
+            keywords,
+            pdfLinks,
+            fullTextLinks,
+            relatedRecords,
+            images,
+            language,
+            label,
+            websiteLink,
+            number,
+            miscellaneous2,
+            typeOfWork,
+            notes,
+            abstr2,
+            numberOfVolumes,
+            originalPublication,
+            publisher,
+            publishingPlace,
+            publicationYear,
+            reviewedItem,
+            researchNotes,
+            reprintEdition,
+            section,
+            isbnIssn,
+            startPage,
+            shortTitle,
+            primaryTitle,
+            secondaryTitle,
+            tertiaryTitle,
+            translatedAuthor,
+            title,
+            translatedTitle,
+            userDefinable1,
+            userDefinable2,
+            userDefinable3,
+            userDefinable4,
+            userDefinable5,
+            url,
+            volumeNumber,
+            publisherStandardNumber,
+            primaryDate,
+            accessDate
+        )
+    }
+}

--- a/subprojects/kris/src/test/kotlin/com/gmail/gcolaianni5/jris/KrisParsingSpec.kt
+++ b/subprojects/kris/src/test/kotlin/com/gmail/gcolaianni5/jris/KrisParsingSpec.kt
@@ -1,7 +1,5 @@
 package com.gmail.gcolaianni5.jris
 
-import com.gmail.gcolaianni5.jris.JRis
-import com.gmail.gcolaianni5.jris.RisType
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldHaveSize
 import org.spekframework.spek2.Spek
@@ -33,7 +31,7 @@ object KrisParsingSpec : Spek({
         )
 
         describe("representing a single record") {
-            val risRecords by memoized { JRis.parse(lines.asSequence()) }
+            val risRecords by memoized { JRis.process(lines.asSequence()) }
 
             it("should be parsed into one single RisRecord") { risRecords shouldHaveSize 1 }
             it("should have the reference type $type") { risRecords.first().type shouldEqual RisType.JOUR }
@@ -49,7 +47,7 @@ object KrisParsingSpec : Spek({
 
         describe("representing two records") {
             val twoRecordLines = lines + lines
-            it("should be parsed into one single RisRecord") { JRis.parse(twoRecordLines.asSequence()) shouldHaveSize 2 }
+            it("should be parsed into one single RisRecord") { JRis.process(twoRecordLines.asSequence()) shouldHaveSize 2 }
         }
     }
 })


### PR DESCRIPTION
This PR documents some basic usages of how to use the `JRis` class both from Kotlin (in the form of a Spek specification) and from Java (as a JUnit5 test).

The examples involve calling the import/export functions with different kind of paradigms:

- passing and receiving collections in a blocking way (from Java/Kotlin)
- passing and receiving Observables (RxJava) (from Java)
- passing and receiving kotlin sequences
- passing and receiving kotlin Flow.

The functions are all stubbed as `TODO()` - leaving the implementations for different Pull Requests.

The tests would, therefore, expectedly be failing, and are.skipped to not break the build.

Resolves #4.

Joint effort during [Basel Hackergarten](https://hackergarten.net/) together with @jcornaz and Chris.