### PR TITLE
Implement Stream API to KRisIO

### DIFF
--- a/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/KRisIOIntegrationTest.kt
+++ b/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/KRisIOIntegrationTest.kt
@@ -4,9 +4,9 @@ import ch.difty.kris.domain.RisRecord
 import ch.difty.kris.domain.RisType
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldHaveSize
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.io.File
+import java.util.stream.Collectors.toList
 
 private const val FILE_PATH = "src/integrationTest/resources/sample.ris"
 private const val PAPER_COUNT = 4
@@ -41,6 +41,34 @@ internal class KRisIOIntegrationTest {
     @Test
     fun `can read from file stream`() {
         File(FILE_PATH).inputStream().process() shouldHaveSize PAPER_COUNT
+    }
+
+    @Test
+    fun `can read from reader to stream`() {
+        val parsed = File(FILE_PATH).bufferedReader().processToStream().collect(toList())
+        parsed shouldHaveSize PAPER_COUNT
+
+        parsed.map { it.title } shouldContainAll setOf(
+            "Exposure to traffic noise and air pollution and risk for febrile seizure: a cohort study.",
+            "Impact of Road Traffic Pollution on Pre-eclampsia and Pregnancy-induced Hypertensive Disorders.",
+            "Exposure to long-term air pollution and road traffic noise in relation to cholesterol: A cross-sectional study.",
+            "∂ for Data: Differentiating Data Structures",
+        )
+    }
+
+    @Test
+    fun `can read from file to stream`() {
+        File(FILE_PATH).processToStream().collect(toList()) shouldHaveSize PAPER_COUNT
+    }
+
+    @Test
+    fun `can read from file path to stream`() {
+        FILE_PATH.processToStream().collect(toList()) shouldHaveSize PAPER_COUNT
+    }
+
+    @Test
+    fun `can read from file stream to stream`() {
+        File(FILE_PATH).inputStream().processToStream().collect(toList()) shouldHaveSize PAPER_COUNT
     }
 
     //endregion

--- a/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/usage/KRisIOUsageImportTest.java
+++ b/subprojects/kris-io/src/integrationTest/java/ch/difty/kris/usage/KRisIOUsageImportTest.java
@@ -1,5 +1,6 @@
 package ch.difty.kris.usage;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.*;
@@ -49,5 +50,36 @@ class KRisIOUsageImportTest {
     void canImportFromPath() throws IOException {
         String path = file.getPath();
         assertThat(KRisIO.process(path)).hasSize(1);
+    }
+
+    @Test
+    void canImportFromFileToStream() throws IOException {
+        assertThat(KRisIO
+            .processToStream(file)
+            .collect(toList())).hasSize(1);
+    }
+
+    @Test
+    void canImportFromReaderToStream() throws IOException {
+        BufferedReader reader = new BufferedReader(new FileReader(file));
+        assertThat(KRisIO
+            .processToStream(reader)
+            .collect(toList())).hasSize(1);
+    }
+
+    @Test
+    void canImportFromStreamToStream() throws IOException {
+        InputStream stream = new FileInputStream(file);
+        assertThat(KRisIO
+            .processToStream(stream)
+            .collect(toList())).hasSize(1);
+    }
+
+    @Test
+    void canImportFromPathToStream() throws IOException {
+        String path = file.getPath();
+        assertThat(KRisIO
+            .processToStream(path)
+            .collect(toList())).hasSize(1);
     }
 }

--- a/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ImportExtensions.kt
+++ b/subprojects/kris-io/src/main/kotlin/ch/difty/kris/ImportExtensions.kt
@@ -5,6 +5,7 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.io.Reader
+import java.util.stream.Stream
 
 /**
  * Converts the RISFile lines provided by the reader as receiver into a list of RisRecords.
@@ -34,3 +35,32 @@ public fun String.process(): List<RisRecord> = KRisIO.process(this)
  * or a [KRisException] if the lines cannot be parsed successfully.
  */
 public fun InputStream.process(): List<RisRecord> = KRisIO.process(this)
+
+/**
+ * Converts the RISFile lines provided by the reader as receiver into a stream of RisRecords.
+ * May throw an [IOException] if the reader fails to deliver lines or a [KRisException]
+ * if the lines cannot be parsed successfully.
+ */
+
+public fun Reader.processToStream(): Stream<RisRecord> = KRisIO.processToStream(this)
+
+/**
+ * Converts the RISFile lines in the [File] provided as receiver into a stream of RisRecords.
+ * May throw an [IOException] if the file cannot be read successfully.
+ * or a [KRisException] if the lines cannot be parsed successfully.
+ */
+public fun File.processToStream(): Stream<RisRecord> = KRisIO.processToStream(this)
+
+/**
+ * Converts the RISFile lines from the file with the path provided as receiver into a stream of RisRecords.
+ * May throw an [IOException] if the file cannot be read successfully.
+ * or a [KRisException] if the lines cannot be parsed successfully.
+ */
+public fun String.processToStream(): Stream<RisRecord> = KRisIO.processToStream(this)
+
+/**
+ * Converts the RISFile lines provided by the [InputStream] as receiver into a stream of RisRecords.
+ * May throw an [IOException] if the stream cannot be read successfully.
+ * or a [KRisException] if the lines cannot be parsed successfully.
+ */
+public fun InputStream.processToStream(): Stream<RisRecord> = KRisIO.processToStream(this)


### PR DESCRIPTION
**Changes:**
When parsing on large RIS files (40k+ records) I've noticed large memory consumption. I think `KRisIO` could expose API with java stream to enable users to utilise stream on their own.